### PR TITLE
Allow gRPC server host to use alternate annotations

### DIFF
--- a/grpc-spring/src/main/java/com/salesforce/grpc/contrib/spring/GrpcServerFactory.java
+++ b/grpc-spring/src/main/java/com/salesforce/grpc/contrib/spring/GrpcServerFactory.java
@@ -7,10 +7,13 @@
 
 package com.salesforce.grpc.contrib.spring;
 
+import com.google.common.collect.ImmutableList;
 import io.grpc.BindableService;
 import io.grpc.Server;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Implement this interface in a bean to override how {@link GrpcServerHost} initializes a {@link Server} from a
@@ -25,4 +28,15 @@ public interface GrpcServerFactory {
      * @return A new grpc {@link Server}
      */
     Server buildServerForServices(int port, Collection<BindableService> services);
+
+    /**
+     * The {@link Annotation}s this GrpcServerFactory will match on when discovering gRPC service implementations.
+     * Override this method to provide your own set of annotations instead of the default
+     * {@code {@literal @}GrpcService} annotation.
+     *
+     * @return a set of java annotations to match on.
+     */
+    default List<Class<? extends Annotation>> forAnnotations() {
+        return ImmutableList.of(GrpcService.class);
+    }
 }

--- a/grpc-spring/src/test/java/com/salesforce/grpc/contrib/spring/AlsoAGrpcService.java
+++ b/grpc-spring/src/test/java/com/salesforce/grpc/contrib/spring/AlsoAGrpcService.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2017, salesforce.com, inc.
+ *  All rights reserved.
+ *  Licensed under the BSD 3-Clause license.
+ *  For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.grpc.contrib.spring;
+
+import org.springframework.stereotype.Service;
+
+import java.lang.annotation.*;
+
+/**
+ * {@code GrpcService} is an annotation that is used to mark a gRPC service implementation for automatic inclusion in
+ * your server.
+ */
+@Service
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface AlsoAGrpcService {
+
+}

--- a/grpc-spring/src/test/java/com/salesforce/grpc/contrib/spring/GrpcServerHostEndToEndTest.java
+++ b/grpc-spring/src/test/java/com/salesforce/grpc/contrib/spring/GrpcServerHostEndToEndTest.java
@@ -7,6 +7,7 @@
 
 package com.salesforce.grpc.contrib.spring;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -23,7 +24,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -101,6 +104,11 @@ public class GrpcServerHostEndToEndTest {
                     System.out.println("Building a service for " + services.size() + " services");
                     return super.buildServerForServices(port, services);
                 }
+
+                @Override
+                public List<Class<? extends Annotation>> forAnnotations() {
+                    return ImmutableList.of(GrpcService.class, AlsoAGrpcService.class);
+                }
             };
         }
 
@@ -111,6 +119,7 @@ public class GrpcServerHostEndToEndTest {
     }
 
     @GrpcService
+    @AlsoAGrpcService
     private static class GreeterImpl extends GreeterGrpc.GreeterImplBase {
         @Autowired
         private GreetingComposer composer;

--- a/grpc-spring/src/test/java/com/salesforce/grpc/contrib/spring/GrpcServerHostTest.java
+++ b/grpc-spring/src/test/java/com/salesforce/grpc/contrib/spring/GrpcServerHostTest.java
@@ -167,7 +167,7 @@ public class GrpcServerHostTest {
         assertThatThrownBy(runner::start).isInstanceOf(IOException.class);
 
         // Make sure the server builder was not used.
-        verifyZeroInteractions(factory);
+        verify(factory, never()).buildServerForServices(anyInt(), any());
 
         assertThat(runner.server()).isNull();
     }

--- a/grpc-spring/src/test/java/com/salesforce/grpc/contrib/spring/InProcessGrpcService.java
+++ b/grpc-spring/src/test/java/com/salesforce/grpc/contrib/spring/InProcessGrpcService.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2017, salesforce.com, inc.
+ *  All rights reserved.
+ *  Licensed under the BSD 3-Clause license.
+ *  For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.grpc.contrib.spring;
+
+import org.springframework.stereotype.Service;
+
+import java.lang.annotation.*;
+
+/**
+ * {@code GrpcService} is an annotation that is used to mark a gRPC service implementation for automatic inclusion in
+ * your server.
+ */
+@Service
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface InProcessGrpcService {
+
+}


### PR DESCRIPTION
This allows a `GrpcServerFactory` to specify which java annotations it looks for. This change allows consumers to create one `GrpcServerHost` for network services, and a different host for InProcess services at the same time.

Alternatively, on host can host real services while the other hosts test doubles.