### PR TITLE
Fix generated class names for nested protos without java_class_name

### DIFF
--- a/jprotoc-test/src/test/proto/com/example/v1/frontend.proto
+++ b/jprotoc-test/src/test/proto/com/example/v1/frontend.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package com.example.v2;
+
+import "google/protobuf/timestamp.proto";
+
+service Frontend {
+    rpc Heartbeat(HeartbeatRequest) returns (HeartbeatRequest);
+}
+message HeartbeatRequest {
+    google.protobuf.Timestamp timestamp = 1;
+}


### PR DESCRIPTION
Fixes 
* https://github.com/salesforce/reactive-grpc/issues/52
* https://github.com/salesforce/reactive-grpc/issues/55