### PR TITLE
canteen: Pass Environment Variables

### DIFF
--- a/canteen/canteen-bootstrap/src/main/go/main.go
+++ b/canteen/canteen-bootstrap/src/main/go/main.go
@@ -45,7 +45,7 @@ func main() {
 			}
 		}
 	} else {
-		err = syscall.Exec(binary, append([]string{"java"}, args...), nil)
+		err = syscall.Exec(binary, append([]string{"java"}, args...), os.Environ())
 		if err != nil {
 			log.Fatalf("Bootstrap execution error: %v", os.Environ())
 		}


### PR DESCRIPTION
Canteen currently does not pass its environment variables to `java` process on macOS, and it is problematic in certain case: when `binary` found by `exec.LookPath` is `/usr/bin/java`.
On macOS, `/usr/bin/java` finds and executes the actual java executable by searching `${JAVA_HOME}`, which is not defined in this case, hence results in error `No Java runtime present, requesting install`.