### PR TITLE
Issue #163 ProtoTypeMap - Outer class incorrect if protobuf name is not lower underscore

### DIFF
--- a/jprotoc/jprotoc-test/src/test/java/com/salesforce/jprotoc/ProtoTypeMapTest.java
+++ b/jprotoc/jprotoc-test/src/test/java/com/salesforce/jprotoc/ProtoTypeMapTest.java
@@ -1,5 +1,7 @@
 package com.salesforce.jprotoc;
 
+import HELLOworld.FunWITHcasEs;
+import HELLOworld.HelloUPPERRequest;
 import com.google.common.io.ByteStreams;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.ExtensionRegistry;
@@ -61,6 +63,11 @@ public class ProtoTypeMapTest {
         assertProtoTypeMapping(".nested.Outer.MiddleAA.Inner", nested.NestedOuterClass.Outer.MiddleAA.Inner.class);
         assertProtoTypeMapping(".nested.Outer.MiddleBB", nested.NestedOuterClass.Outer.MiddleBB.class);
         assertProtoTypeMapping(".nested.Outer.MiddleBB.Inner", nested.NestedOuterClass.Outer.MiddleBB.Inner.class);
+    }
+
+    @Test
+    public void nestedTypeCamelCase() {
+        assertProtoTypeMapping(".pkg.Inner", pkg.NestedCamelCase.Inner.class);
     }
 
     /**

--- a/jprotoc/jprotoc-test/src/test/proto/NestedCamelCase.proto
+++ b/jprotoc/jprotoc-test/src/test/proto/NestedCamelCase.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+// release id
+package pkg;
+
+message Inner {
+    optional int32 value = 1;
+}
+

--- a/jprotoc/jprotoc/src/main/java/com/salesforce/jprotoc/ProtoTypeMap.java
+++ b/jprotoc/jprotoc/src/main/java/com/salesforce/jprotoc/ProtoTypeMap.java
@@ -121,8 +121,7 @@ public final class ProtoTypeMap {
         }
 
         filename = makeInvalidCharactersUnderscores(filename);
-        filename = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, filename);
-        filename = upcaseAfterNumber(filename);
+        filename = convertToCamelCase(filename);
         filename = appendOuterClassSuffix(filename, fileDescriptor);
         return filename;
     }
@@ -157,15 +156,32 @@ public final class ProtoTypeMap {
     }
 
     /**
-     * Upper case characters after numbers, like {@code Weyland9Yutani}.
+     * Adjust a class name to follow the JavaBean spec.
+     * - capitalize the first letter
+     * - remove embedded underscores & capitalize the following letter
+     * - capitalize letter after a number
+     *
+     * @param name method name
+     * @return lower name
      */
-    private static String upcaseAfterNumber(String filename) {
-        char[] filechars = filename.toCharArray();
-        for (int i = 1; i < filechars.length; i++) {
-            if (CharMatcher.inRange('0', '9').matches(filechars[i - 1])) {
-                filechars[i] = Character.toUpperCase(filechars[i]);
+    private static String convertToCamelCase(String name) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(Character.toUpperCase(name.charAt(0)));
+
+        for (int i = 1; i < name.length(); i++) {
+            char c = name.charAt(i);
+            char prev = name.charAt(i - 1);
+
+            if (c != '_') {
+                if (prev == '_' || CharMatcher.inRange('0', '9').matches(prev)) {
+                    sb.append(Character.toUpperCase(c));
+                } else {
+                    sb.append(c);
+                }
             }
         }
-        return new String(filechars);
+
+        return sb.toString();
     }
+
 }


### PR DESCRIPTION
Removed forced lower_underscore to camel conversion of Java type names and replaced with manual uppercasing of letters after an underscore.
Names that are already in camel case are not afftected this way.
