### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
See https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/

Consider enabling this : 

![image](https://user-images.githubusercontent.com/8935151/146789935-644ad1e7-d205-4bd8-9e1a-ffe43b1f9304.png)


See sample PRs in my fork : https://github.com/yeikel/grpc-java-contrib/pulls