### PR TITLE
Bump grpc + protoc versions

### DIFF
--- a/jprotoc/pom.xml
+++ b/jprotoc/pom.xml
@@ -58,13 +58,13 @@
         <mavenBaseUrl>https://oss.sonatype.org/content/repositories</mavenBaseUrl>
 
         <!-- Dependency Versions -->
-        <protoc.version>3.15.8</protoc.version>
+        <protoc.version>3.19.4</protoc.version>
         <gson.version>2.8.9</gson.version>
         <mustache-java.version>0.9.10</mustache-java.version>
 
         <!-- Test Dependency Versions -->
         <contrib.version>0.8.1</contrib.version>
-        <grpc.version>1.37.0</grpc.version>
+        <grpc.version>1.45.1</grpc.version>
         <junit.version>4.13.1</junit.version>
         <assertj.version>3.6.2</assertj.version>
         <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
I've experienced an issue trying to use the 3.19.4 version of protoc and grpc-java to being able to compile with a Custom Generator .

Using:
com.google.protobuf.protoc = 3.19.4
protoc-gen-grpc-java.plugin = 1.45.1 (1.37.0 has an internal dependency on protobuf-java that does not contain com.google.protobuf.GeneratedMessageV3.isStringEmpty)

The issue :
The problem is that the latest protoc generates code that depends on function (com.google.protobuf.GeneratedMessageV3.isStringEmpty) that are available from 3.17.3+.

The current issue:
Since jprotoc using shade plugin to create the jar it brings protoc and protobuf  code inside the jar 

2.
It also can solve compatibility with M1 mac : https://github.com/grpc/grpc-java/issues/8724

