### PR TITLE
docs: fix org-less links, wrong artifact badges, stale class/package names, and Maven Central claim

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,16 +17,16 @@ one where new project leads (`admins`) will be added to the project based on the
 Use GitHub Issues page to submit issues, enhancement requests and discuss ideas.
 
 ### Bug Reports and Fixes
--  If you find a bug, please search for it in the [Issues](https://github.com/grpc-java-contrib/issues), and if it isn't 
-   already tracked, [create a new issue](https://github.com/grpc-java-contrib/issues/new). Fill out the "Bug Report" section 
+-  If you find a bug, please search for it in the [Issues](https://github.com/salesforce/grpc-java-contrib/issues), and if it isn't 
+   already tracked, [create a new issue](https://github.com/salesforce/grpc-java-contrib/issues/new). Fill out the "Bug Report" section 
    of the issue template. Even if an Issue is closed, feel free to comment and add details, it will still be reviewed.
 -  Issues that have already been identified as a bug (note: able to reproduce) will be labelled `bug`.
--  If you'd like to submit a fix for a bug, [send a Pull Request](#creating_a_pull_request) and mention the Issue number.
+-  If you'd like to submit a fix for a bug, [send a Pull Request](#creating-a-pull-request) and mention the Issue number.
 -  Include tests that isolate the bug and verifies that it was fixed.
 
 ### New Features
 -  If you'd like to add new functionality to this project, describe the problem you want to solve in a 
-   [new Issue](https://github.com/grpc-java-contrib/issues/new).
+   [new Issue](https://github.com/salesforce/grpc-java-contrib/issues/new).
 -  Issues that have been identified as a feature request will be labelled `enhancement`.
 -  If you'd like to implement the new feature, please wait for feedback from the project
    maintainers before spending too much time writing the code. In some cases, `enhancement`s may
@@ -36,8 +36,8 @@ Use GitHub Issues page to submit issues, enhancement requests and discuss ideas.
 -  If you'd like to improve the tests, you want to make the documentation clearer, you have an
    alternative implementation of something that may have advantages over the way its currently
    done, or you have any other change, we would be happy to hear about it!
--  If its a trivial change, go ahead and [send a Pull Request](#creating_a_pull_request) with the changes you have in mind.
--  If not, [open an Issue](https://github.com/grpc-java-contrib/issues/new) to discuss the idea first.
+-  If its a trivial change, go ahead and [send a Pull Request](#creating-a-pull-request) with the changes you have in mind.
+-  If not, [open an Issue](https://github.com/salesforce/grpc-java-contrib/issues/new) to discuss the idea first.
 
 If you're new to our project and looking for some way to make your first contribution, look for
 Issues labelled `good first contribution`.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ A pair of demo applications are in the [`grpc-java-contrib-demo`](https://github
 
 Usage
 =====
-These libraries are still fairly immature. For now, you will have to clone this repo and build it yourself. Setting
-up CI and deploying to Maven Central is still in our future.
+Binaries are published to Maven Central under the `com.salesforce.servicelibs` group id.
 
 See each respective module for documentation on its usage.
 

--- a/contrib/grpc-contrib/README.md
+++ b/contrib/grpc-contrib/README.md
@@ -19,4 +19,3 @@ Subpackages
 * *context* - Implements an ambient context that is transparently passed from service to service.
 * *instancemode* - Adds per-call and per-session service instantiation modes to gRPC.
 * *interceptor* - Useful client and server interceptor implementations.
-* *session* - Adds client session tracking support to gRPC.

--- a/contrib/grpc-contrib/README.md
+++ b/contrib/grpc-contrib/README.md
@@ -1,5 +1,5 @@
 [![Javadocs](https://javadoc.io/badge/com.salesforce.servicelibs/grpc-contrib.svg)](https://javadoc.io/doc/com.salesforce.servicelibs/grpc-contrib)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.salesforce.servicelibs/grpc-contrib/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.salesforce.servicelibs/grpc-contrib)
+[![Maven Central](https://img.shields.io/maven-central/v/com.salesforce.servicelibs/grpc-contrib)](https://central.sonatype.com/artifact/com.salesforce.servicelibs/grpc-contrib)
 
 Classes
 ==============

--- a/contrib/grpc-spring/README.md
+++ b/contrib/grpc-spring/README.md
@@ -1,5 +1,5 @@
 [![Javadocs](https://javadoc.io/badge/com.salesforce.servicelibs/grpc-spring.svg)](https://javadoc.io/doc/com.salesforce.servicelibs/grpc-spring)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.salesforce.servicelibs/grpc-spring/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.salesforce.servicelibs/grpc-spring)
+[![Maven Central](https://img.shields.io/maven-central/v/com.salesforce.servicelibs/grpc-spring)](https://central.sonatype.com/artifact/com.salesforce.servicelibs/grpc-spring)
 
 Using GrpcServerHost
 ====================

--- a/contrib/grpc-testing-contrib/README.md
+++ b/contrib/grpc-testing-contrib/README.md
@@ -1,7 +1,7 @@
-[![Javadocs](https://javadoc.io/badge/com.salesforce.servicelibs/grpc-contrib.svg)](https://javadoc.io/doc/com.salesforce.servicelibs/grpc-contrib)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.salesforce.servicelibs/grpc-contrib/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.salesforce.servicelibs/grpc-contrib)
+[![Javadocs](https://javadoc.io/badge/com.salesforce.servicelibs/grpc-testing-contrib.svg)](https://javadoc.io/doc/com.salesforce.servicelibs/grpc-testing-contrib)
+[![Maven Central](https://img.shields.io/maven-central/v/com.salesforce.servicelibs/grpc-testing-contrib)](https://central.sonatype.com/artifact/com.salesforce.servicelibs/grpc-testing-contrib)
 
 Classes
 ==============
 * *NettyGrpcServerRule* - A jUnit test @Rule like `GrpcServerRule`, but uses the Netty transport instead of the InProc transport.
-* *GrpcContext* - A jUnit test @Rule that fails any test that leaks `io.grpc.Context` information. Useful for testing context-sensitive code.
+* *GrpcContextRule* - A jUnit test @Rule that fails any test that leaks `io.grpc.Context` information. Useful for testing context-sensitive code.

--- a/jprotoc/jprotoc/README.md
+++ b/jprotoc/jprotoc/README.md
@@ -1,7 +1,7 @@
 What is jprotoc?
 ================
 [![Javadocs](https://javadoc.io/badge/com.salesforce.servicelibs/jprotoc.svg)](https://javadoc.io/doc/com.salesforce.servicelibs/jprotoc)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.salesforce.servicelibs/jprotoc/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.salesforce.servicelibs/jprotoc)
+[![Maven Central](https://img.shields.io/maven-central/v/com.salesforce.servicelibs/jprotoc)](https://central.sonatype.com/artifact/com.salesforce.servicelibs/jprotoc)
 
 
 jprotoc is a framework for building protoc plugins using Java. As a demo, jprotoc includes a Jdk8 generator, that


### PR DESCRIPTION
Five commits, all documentation (six .md files):

1. **CONTRIBUTING.md** — the Issues links (`github.com/grpc-java-contrib/issues`) are missing the `salesforce/` org segment and 404; the in-page anchors used `#creating_a_pull_request` where GitHub slugs the heading with hyphens.
2. **grpc-testing-contrib README** — both badges referenced the `grpc-contrib` artifact instead of this module's `grpc-testing-contrib` (published on Central — verified), and the documented `@Rule` class is `GrpcContextRule`; no `GrpcContext` class exists in the module.
3. **All module READMEs** — `maven-badges.herokuapp.com` badge images have returned 404 since the Heroku free-tier shutdown; replaced with shields.io badges (verified 200) linking to central.sonatype.com.
4. **grpc-contrib README** — removed the `session` subpackage bullet; the module's subpackages are `context`, `instancemode`, `interceptor`, and `xfcc`.
5. **Root README** — dropped "you will have to clone this repo and build it yourself… deploying to Maven Central is still in our future": the `com.salesforce.servicelibs` artifacts are published on Maven Central (javadoc.io/Central verified).

**Verification:** class/package names checked against the source tree; artifact availability and badge URLs curl-verified. `mvn test` cannot complete on this machine on **unmodified master either** — the protobuf plugin requires a `jprotoc:exe:osx-aarch_64` protoc plugin binary that was never published for Apple Silicon (identical failure with and without this diff, which touches only markdown).

Prepared with AI assistance (Claude).